### PR TITLE
[AJR] Implement 'validate_env' method

### DIFF
--- a/lib/rbtc_arbitrage/clients/circle_client.rb
+++ b/lib/rbtc_arbitrage/clients/circle_client.rb
@@ -20,6 +20,7 @@ module RbtcArbitrage
 
       # Configures the client's API keys.
       def validate_env
+        validate_keys :circle_customer_session_token, :circle_cookie
       end
 
       # `action` is :buy or :sell


### PR DESCRIPTION
Implements the 'validate_env' method.

This enforces the requirement that the `:circle_customer_session_token` and `:circle_cookie` environment variables are set.
